### PR TITLE
Various fixes & Title Format selection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ add this to your `mpv.conf`:
 profile-cond=os.execute("/path/to/anipresence.py > /dev/null &")
 ```
 
+## show titles on discord
+
+shows usually have three official titles that AL reconizes and makes easily accessible:
+
+`Romaji`, `Native` and `English`. for [EVA](https://anilist.co/anime/30/Shin-Seiki-Evangelion/) that would be "Shin Seiki Evangelion", "新世紀エヴァンゲリオン" and "Neon Genesis Evangelion". anipresence uses romaji as the default title format.
+
+to select which title format to use, set argument `-t` or `--titleformat` with the options `r | romaji | n | native | e | english`. 
+
+should you, for example, want enlish titles just change the `mpv.conf` entry to:
+
+```ini
+[discord-rpc]
+profile-cond=os.execute("/path/to/anipresence.py -t e > /dev/null &")
+```
+_**note:**_ anipresence saves only one so called "display title". if you decide to change the title format, all shows watched _before_ this change will still show their title in the _old_ title format.
+ 
 ## nicer titles
 
 patch `ani-cli`:
@@ -32,4 +48,4 @@ patch `ani-cli`:
 +       mpv*) nohup "$player_function" --force-media-title="${title}episode-${ep_no}-${mode}" "$episode" >/dev/null 2>&1 & ;;
 ```
 
-check `./ani-patch.sh` for an automated way of pataching `ani-cli`
+check `./ani-patch.sh` for an automated way of patching `ani-cli`

--- a/anipresence.py
+++ b/anipresence.py
@@ -39,6 +39,11 @@ class Anime:
         self.title_format = format
 
 
+def cmp_str(str_1, str_2) -> bool:
+    a = str_1.lower().replace(" ", "")
+    b = str_2.lower().replace(" ", "")
+    return a == b
+
 class MetaDataCache:
     cache = {}
     cache_path = None
@@ -122,21 +127,21 @@ class MetaDataCache:
             # romaji
             filtered_a = list(
                 filter(
-                    lambda a: a["title"]["romaji"].lower() == anime.mpv_title.lower(),
+                    lambda a: cmp_str(a["title"]["romaji"], anime.mpv_title),
                     json_animes,
                 )
             )
             # english
             filtered_b = list(
                 filter(
-                    lambda a: a["title"]["english"] is not None and a["title"]["english"].lower() == anime.mpv_title.lower(),
+                    lambda a: a["title"]["english"] is not None and cmp_str(a["title"]["english"], anime.mpv_title),
                     json_animes,
                 )
             )
             # synonyms
             filtered_c = list(
                 filter(
-                    lambda a: len(a["synonyms"]) != 0 and any(i.lower() == anime.mpv_title.lower() for i in a["synonyms"]),
+                    lambda a: len(a["synonyms"]) != 0 and any(cmp_str(i.lower(), anime.mpv_title) for i in a["synonyms"]),
                     json_animes,
                 )
             )
@@ -266,9 +271,12 @@ class AniPresence:
             "details": f"{self.anime.display_title}",
             "state": ep_line,
             "large_image":self.anime.imglink,
-            "start": int(time.time()),
-            "end": int(time.time()) + int(self.anime.duration) * 60
+            "start": int(time.time())
         }
+
+        if self.anime.duration != 0:
+            update_args["end"] = int(time.time()) + int(self.anime.duration) * 60
+
         self.rpc.clear()
 
         if ACTIVITY_TYPE_SUPPORT:


### PR DESCRIPTION
**This Branch has changes that _could_ break your cache file**

The original goal was to be able to select if anipresence displays the title of the currently playing media in romaji, english or native

along the way there were a couple of things that i noticed and fixed/changed
- originally the `epcount` should have been extractable from mpv. idk if this ever worked, but for the last two years (according to my histfile) this did no work and instead of the epcount `None` was used instead. Since we can't get the epcount _before_ making a call to AL (just the current ep) i removed this.
- this means all old Keys for searching were `Romaji Title -- None` this now actually makes it possible to (hopefully) not break existing histfiles, since the new key is just `Romaji Title`
-  as epcount was also being used in the search i have removed it there and instead we now search both romaji and english titles (should the latter ones exist)
- for a more structured approach there is now a `Anime` class, holding all relevant variables.
- Currently the TitleFormat selection is hard-coded, but when cleaning up i plan to make this accessible via cli args

I have tested this with a couple of shows, but there are likely still some bugs/weird edge-cases that are unaccounted for

also i have added the duration and plan to check the pypresence version and, based on that, make use of the new features that are only in the git version (aka setting the activity type to "Watching" instead of "Playing" and adding a progress bar)